### PR TITLE
bump webrtcsupport to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "filetransfer": "^2.0.0",
     "localmedia": "^1.0.2",
     "rtcpeerconnection": "^3.0.6",
-    "webrtcsupport": "^1.2.4",
+    "webrtcsupport": "^2.2.0",
     "wildemitter": "1.x",
     "socket.io-client": "0.9.16",
     "attachmediastream": "1.0.1",


### PR DESCRIPTION
since the webrtcsupport 1.x and 2.x apis are incompatible this is a breaking change I think.