### PR TITLE
modified testReadiness to emit readyToCall event if video and audio configurations are set to false

### DIFF
--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -437,10 +437,8 @@ SimpleWebRTC.prototype.testReadiness = function () {
     if (this.sessionReady) {
         if (!this.config.media.video && !this.config.media.audio) {
             self.emit('readyToCall', self.connection.getSessionid());
-        } else {
-            if (this.webrtc.localStreams.length > 0) {
-                self.emit('readyToCall', self.connection.getSessionid());
-            }
+        } else if (this.webrtc.localStreams.length > 0) {
+            self.emit('readyToCall', self.connection.getSessionid());
         }
     }
 };

--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -434,8 +434,14 @@ SimpleWebRTC.prototype.stopScreenShare = function () {
 
 SimpleWebRTC.prototype.testReadiness = function () {
     var self = this;
-    if (this.webrtc.localStreams.length > 0 && this.sessionReady) {
-        self.emit('readyToCall', self.connection.getSessionid());
+    if (this.sessionReady) {
+        if (!this.config.media.video && !this.config.media.audio) {
+            self.emit('readyToCall', self.connection.getSessionid());
+        } else {
+            if (this.webrtc.localStreams.length > 0) {
+                self.emit('readyToCall', self.connection.getSessionid());
+            }
+        }
     }
 };
 


### PR DESCRIPTION
This is related to https://github.com/andyet/SimpleWebRTC/issues/338 .  I wrote some basic code in my client to determine if there were any audio or video devices, and pass those booleans into the config.media struct.  However, the readyToCall event is never emitted if there are no local streams.  It seems logical that if we configure there to be no streams (config.media.video == false and config.media.audio == false), that we should still emit the readyToCall event so we can join the room in the callback.