### PR TITLE
Add `localScreenRemoved` event.  Check for stream.stop before calling.

### DIFF
--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -231,6 +231,7 @@ function SimpleWebRTC(opts) {
         });
     });
     this.webrtc.on('localScreenStopped', function (stream) {
+        self.emit('localScreenRemoved');
         self.stopScreenShare();
         /*
         self.connection.emit('unshareScreen');
@@ -428,7 +429,7 @@ SimpleWebRTC.prototype.stopScreenShare = function () {
     // a hack to emit the event the removes the video
     // element that we want
     if (videoEl) this.emit('videoRemoved', videoEl);
-    if (stream) stream.stop();
+    if (stream && stream.stop) stream.stop();
     this.webrtc.peers.forEach(function (peer) {
         if (peer.broadcaster) {
             peer.end();


### PR DESCRIPTION
In chrome, if user clicks 'stop screen sharing', this will emit an event the UI can react to.    

```
self.emit('localScreenRemoved');
```

This is symmetrical to the `videoRemoved` and `localScreenAdded` events.

Also a coding check for stopping undefined or older streams to prevent errors.

Thanks!
