### PR TITLE
add 'localVideoAdded' event, emitted when user's own stream is added

### DIFF
--- a/simplewebrtc.bundle.js
+++ b/simplewebrtc.bundle.js
@@ -374,6 +374,7 @@ SimpleWebRTC.prototype.startLocalVideo = function () {
             self.emit('localMediaError', err);
         } else {
             attachMediaStream(stream, self.getLocalVideoContainer(), self.config.localVideo);
+            self.emit('localVideoAdded', stream);
         }
     });
 };


### PR DESCRIPTION
'localVideoAdded' - emitted when user's own stream is added to the screen, return user's own mediaStream in callback