### PR TITLE
Improved compatibility on IE8

### DIFF
--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -247,12 +247,9 @@ function SimpleWebRTC(opts) {
     if (this.config.autoRequestMedia) this.startLocalVideo();
 }
 
+SimpleWebRTC.prototype = new WildEmitter();
 
-SimpleWebRTC.prototype = Object.create(WildEmitter.prototype, {
-    constructor: {
-        value: SimpleWebRTC
-    }
-});
+SimpleWebRTC.prototype.constructor = SimpleWebRTC;
 
 SimpleWebRTC.prototype.leaveRoom = function () {
     if (this.roomName) {


### PR DESCRIPTION
Some ancient browsers like IE8 does not know the `Object.create` function as it was introduced in IE9.
If the bundle is included into a minified source it results into a broken script and will not run.
With this modification everything will work.