### PR TITLE
added roomName in createdPeer event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplewebrtc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:henrikjoreteg/SimpleWebRTC.git"

--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -345,7 +345,7 @@ SimpleWebRTC.prototype.joinRoom = function (name, cb) {
                                 offerToReceiveVideo: self.config.receiveMedia.offerToReceiveVideo
                             }
                         });
-                        self.emit('createdPeer', peer);
+                        self.emit('createdPeer', peer, self.roomName);
                         peer.start();
                     }
                 }


### PR DESCRIPTION
createdPeer is an event called for each joined room then I suppose that is better to have roomName as parameter in the callback to manage presence or autosend message in the room channel better.