### PR TITLE
bump rtcpeerconnection to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "filetransfer": "^2.0.4",
     "localmedia": "^2.0.0",
-    "rtcpeerconnection": "^4.0.0",
+    "rtcpeerconnection": "^5.0.0",
     "webrtcsupport": "^2.2.0",
     "wildemitter": "1.x",
     "socket.io-client": "1.3.7",


### PR DESCRIPTION
@legastero I think you forgot this after https://github.com/otalk/RTCPeerConnection/pull/64 :-)
no direct api changes, right? 4.x -> 5.x was mostly in case anyone builds on sjj (which this doesn't)