### PR TITLE
fixing bug related to removing multiple peers while leavin…

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -253,9 +253,12 @@ Peer.prototype.handleRemoteStreamAdded = function (event) {
 };
 
 Peer.prototype.handleStreamRemoved = function () {
-    this.parent.peers.splice(this.parent.peers.indexOf(this), 1);
-    this.closed = true;
-    this.parent.emit('peerStreamRemoved', this);
+    var peerIndex = this.parent.peers.indexOf(this);
+    if (peerIndex > -1) {
+        this.parent.peers.splice(peerIndex, 1);
+        this.closed = true;
+        this.parent.emit('peerStreamRemoved', this);
+    }
 };
 
 Peer.prototype.handleDataChannelAdded = function (channel) {

--- a/simplewebrtc.js
+++ b/simplewebrtc.js
@@ -258,7 +258,7 @@ SimpleWebRTC.prototype.leaveRoom = function () {
     if (this.roomName) {
         this.connection.emit('leave');
         while (this.webrtc.peers.length) {
-            this.webrtc.peers.shift().end();
+            this.webrtc.peers[0].end();
         }
         if (this.getLocalScreen()) {
             this.stopScreenShare();


### PR DESCRIPTION
…g a room

#300 doesn't completely solve #176 because of the "peers" Object's mutability. As such, leaveRoom() will not correctly end all peers.

Using shift() removes the peer from the "peers" Object and calling end() triggers handleStreamRemoved() which in turn searches for an already-removed Peer which leads to a splice(-1,1). This .splice call removes an extra peer at the end of the "peers" Object without calling end() on it which in turn leads to a Peer not being cleaned up when leaveRoom() is called.

@chairmanwow helped debug this.

JSHint is happy.
All current tests pass.
There are no new tests.