### PR TITLE
remove the need for the old api.talky.io

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -169,7 +169,6 @@ if (room) {
 
 function GUM() {
     webrtc = new SimpleWebRTC({
-        url: 'https://api.talky.io', // this will only work from simplewebrtc.com, please use the default sandbox otherwise
         // we don't do video
         localVideoEl: '',
         remoteVideosEl: '',


### PR DESCRIPTION
api.talky.io was used because... it delivered TURN servers for the edge/chrome/firefox interop demo.