### PR TITLE
Apply bandwidth restrictions on both side of connection

### DIFF
--- a/simplewebrtc.bundle.js
+++ b/simplewebrtc.bundle.js
@@ -10704,6 +10704,16 @@ PeerConnection.prototype.handleAnswer = function (answer, cb) {
     cb = cb || function () {};
     var self = this;
     if (answer.jingle) {
+        if (self.restrictBandwidth > 0) {
+            if (answer.jingle.contents.length >= 2 && answer.jingle.contents[1].name === 'video') {
+                var content = answer.jingle.contents[1];
+                var hasBw = content.application && content.application.bandwidth && content.application.bandwidth.bandwidth;
+                if (!hasBw) {
+                    answer.jingle.contents[1].application.bandwidth = { type: 'AS', bandwidth: self.restrictBandwidth.toString() };
+                }
+            }
+        }
+
         answer.sdp = SJJ.toSessionSDP(answer.jingle, {
             sid: self.config.sdpSessionID,
             role: self._role(),


### PR DESCRIPTION
When this.restrictBandwidth is set (on line 10206) to a non-zero value, this is used in handleOffer to add a limit on the bandwidth the video channel is allowed to use (only when useJingle is true).  There is no corresponding limit in handleAnswer, however, so the channel proposer does not have any bandwidth limit applied, even though the answerer does.

This change adds the same restriction to that side of the channel.

One can test this by changing

```
@@ -10203,7 +10203,7 @@ function PeerConnection(config, constraints) {
         });
     }
     // EXPERIMENTAL FLAG, might get removed without notice
-    this.restrictBandwidth = 0;
+    this.restrictBandwidth = 10;
     if (constraints && constraints.optional) {
         constraints.optional.forEach(function (constraint) {
             if (constraint.andyetRestrictBandwidth) {
@@ -10312,7 +10312,7 @@ function PeerConnection(config, constraints) {
         sid: '',
         isInitiator: true,
         sdpSessionID: Date.now(),
-        useJingle: false
+        useJingle: true
     };

     this.iceCredentials = {
```

and visually observing the reduced transmission quality on both sides of a two-party chat (vs only affecting one side before this change).  (see below)


The 10 lines of code I've added are copied from handleOffer, 80 lines earlier, just with answer replacing offer in a few spots.  I wasn't sure where to put a function abstracting that logic.

before: (note quality of bottom left image)
![before](https://cloud.githubusercontent.com/assets/508646/22264837/7075d97e-e247-11e6-8e22-8c80ffd8428e.png)
after:
![after](https://cloud.githubusercontent.com/assets/508646/22264838/762646f6-e247-11e6-897f-876e43d0dee1.png)
