### PR TITLE
Fix for Error: Can't resolve 'simplewebrtc' when installing it with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/andyet/SimpleWebRTC.git"
   },
-  "main": "./simplewebrtc.js",
+  "main": "./out/simplewebrtc-with-adapter.bundle.js",
   "description": "World's easiest webrtc",
   "dependencies": {
     "filetransfer": "^2.0.4",


### PR DESCRIPTION
Installing from npm and using it with Webpack

Changed the main file to './out/simplewebrtc-with-adapter.bundle.js' so that require('simplewebrtc') or import statements will directly get the simplewebrtc javascript file with adapter.