### PR TITLE
Remote video wrapper to overcome aspect ratio differences

### DIFF
--- a/src/simplewebrtc.js
+++ b/src/simplewebrtc.js
@@ -280,13 +280,17 @@ SimpleWebRTC.prototype.disconnect = function () {
 SimpleWebRTC.prototype.handlePeerStreamAdded = function (peer) {
     var self = this;
     var container = this.getRemoteVideoContainer();
+    var wrapper = document.createElement('div');
     var video = attachMediaStream(peer.stream);
 
     // store video element as part of peer for easy removal
     peer.videoEl = video;
     video.id = this.getDomId(peer);
 
-    if (container) container.appendChild(video);
+    if (container) {
+      wrapper.appendChild(video);
+      container.appendChild(wrapper);
+    }
 
     this.emit('videoAdded', video, peer);
 

--- a/src/simplewebrtc.js
+++ b/src/simplewebrtc.js
@@ -312,7 +312,7 @@ SimpleWebRTC.prototype.handlePeerStreamRemoved = function (peer) {
     var container = this.getRemoteVideoContainer();
     var videoEl = peer.videoEl;
     if (this.config.autoRemoveVideos && container && videoEl) {
-        container.removeChild(videoEl);
+        container.firstChild.removeChild(videoEl);
     }
     if (videoEl) this.emit('videoRemoved', videoEl, peer);
 };

--- a/src/simplewebrtc.js
+++ b/src/simplewebrtc.js
@@ -310,9 +310,10 @@ SimpleWebRTC.prototype.handlePeerStreamAdded = function (peer) {
 
 SimpleWebRTC.prototype.handlePeerStreamRemoved = function (peer) {
     var container = this.getRemoteVideoContainer();
+    var videoElWrapper = peer.videoEl.parentElement;
     var videoEl = peer.videoEl;
-    if (this.config.autoRemoveVideos && container && videoEl) {
-        container.firstChild.removeChild(videoEl);
+    if (this.config.autoRemoveVideos && container && videoElWrapper) {
+        container.removeChild(videoElWrapper);
     }
     if (videoEl) this.emit('videoRemoved', videoEl, peer);
 };


### PR DESCRIPTION
Adding a wrapping DIV for each remote video, so we can overcome aspect ratio differences with CSS.

The following CSS will produce a borderless mosaic of videos, each one of them taking 25% of the screen width and height:

```
.local-video-wrapper, #remote-videos div {
   width: 25%;
   float: left;
   height: 25vh;
   position: relative;
   overflow: hidden;
 }

video {
   object-fit: cover;
   width: 100%;
   height: 100%;
}
```